### PR TITLE
refactor(util): adjust the judgment of isWX

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,7 +107,11 @@ function easeInOutExpo(pos) {
 
 
 export function isWX() {
-  return !window
+  try {
+    return Boolean(wx.getSystemInfoSync);
+  } catch {
+    return false
+  }
 }
 
 export function isEndNode(el) {


### PR DESCRIPTION
在使用跨端的小程序框架时，通过判断是否存在 window 对象来确定是否处于小程序环境是不够的，比如 taro 就通过了 `webpack provider-plugin` 注入了 window